### PR TITLE
Skeleton for rule-based `CostModel`

### DIFF
--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -11,7 +11,9 @@ from pandasql.cost_model import CostModel
 DB_FILE = mkstemp("_pandasql.db")[1]
 SQL_CON = get_sqlite_connection(DB_FILE)
 OFFLOADING_STRATEGY = None
+SQLITE_CHUNK_SIZE = 10000
 COST_MODEL = CostModel()
+
 
 def require_result(func):
     '''Decorator for functions that require results to be ready'''
@@ -374,7 +376,8 @@ class DataFrame(BaseFrame):
 
         if df is not None and len(df) > 0:
             # Offload dataframe to SQLite
-            df.to_sql(name=self.name, con=SQL_CON, index=False, chunksize=10000)
+            df.to_sql(name=self.name, con=SQL_CON,
+                      index=False, chunksize=SQLITE_CHUNK_SIZE)
             self._cached_on_sqlite = True
 
             # Store columns

--- a/pandasql/cost_model.py
+++ b/pandasql/cost_model.py
@@ -1,57 +1,104 @@
 from pandasql.utils import _get_dependency_graph
 import pandasql as ps
 
+
 class CostModel(object):
-    def __init__(self, max_pandas_len=10, max_pandas_input=500_000_000 ): #500 MB
-        self.transfer_cost = 0 # GB/s
+    def __init__(self, max_pandas_len=10,
+                 max_pandas_input=500_000_000):  # 500 MB
+        self.transfer_rate = 0  # GB/s
         self.required_pandas_ops = []
         self.required_sql_ops = []
-        self.system_memory_size = 0
+        self.system_memory_size = 0  # TODO: automate finding this
         self.max_pandas_len = max_pandas_len
         self.max_pandas_input = max_pandas_input
         self.compute_path = []
 
     def should_offload(self, df):
-
-        # possible_executions = []
         graph = _get_dependency_graph(df)
-        query_height = len(graph)
-        #TODO: Only sum input_sizes for nodes that we compute from (don't double count)
-        estimated_input = sum([g.memory_usage for g in graph])
 
-        limits = [g.n for g in graph if isinstance(g, ps.core.Limit)]
-        filters = [g.criterion for g in graph if isinstance(g, ps.core.Selection)]
-        aggregations = [g.agg for g in graph if isinstance(g, ps.core.Aggregator)]
-        joins = [g.left_keys for g in graph if isinstance(g, ps.core.Join)]
+        for rule in OFFLOADING_RULES:
+            if rule(df, graph):
+                return True
 
-        # print(num_limits, num_filters, num_aggregations, num_joins)
-        print([type(g) for g in graph])
-
-        print(estimated_input, self.max_pandas_input)
-
-        # if query_height > self.max_pandas_len:
-        #     print('offloading from query height')
-        #     return True
-
-        if estimated_input > self.max_pandas_input:
-            print('offloading from input size')
-            return True
-
-        if len(aggregations) + len(joins) > 2:
-            print('offloading from agg/join')
-            return True
-
-        if len(limits) > 0 and min(limits) < 10000:
-            print('offloading from limit')
-            return True
+        return False
 
 
-        else:
-            return False
-        # execution_estimates = []
-        # for pe in possible_executions:
-            # cost = 0 # some formula
-            # execution time + possible data transfer time
-            # we in
-            # execution_estimates.append(pe, cost)
-        # best_plan = min(execution_estimates, key = lambda t: t[1])
+##############################################################################
+#                           Offloading Rules
+##############################################################################
+
+MAX_DEPENDENCY_DISTANCE = 1   # TODO: How much should we allow? Maybe 2-3?
+
+
+def _out_of_memory(df, graph):
+    # TODO: How should we estimate memory usage of a query?
+    return NotImplemented
+
+
+def _join_then_restrict(df, graph):
+    for node in graph.keys():
+        # TODO: Look at size of filter/limit for this decision?
+        if isinstance(node, ps.core.Selection) or \
+                isinstance(node, ps.core.Limit):
+            join_ancestors = _filter_ancestors(node, graph,
+                                               lambda x:
+                                               isinstance(x, ps.core.Join))
+            if len(join_ancestors) > 0:
+                return True
+
+    return False
+
+
+def _limit_output(df, graph):
+    return isinstance(df, ps.core.Limit)
+
+
+def _deep_dependency_graph(df, graph):
+    ancestors_by_depth = _get_ancestors_by_depth(df, graph)
+    depth = len(ancestors_by_depth)
+    return depth > 5
+
+
+OFFLOADING_RULES = [
+    # _out_of_memory,
+    _join_then_restrict,
+    _limit_output,
+    _deep_dependency_graph,
+    # TODO: more rules
+]
+
+
+##############################################################################
+#                       Common Utility Functions
+##############################################################################
+
+
+def _filter_ancestors(df, graph, predicate,
+                      max_depth=MAX_DEPENDENCY_DISTANCE):
+    ancestors_by_depth = _get_ancestors_by_depth(df, graph, max_depth)
+    filtered = []
+    for ancestors in ancestors_by_depth.values():
+        filtered.extend(filter(predicate, ancestors))
+    return filtered
+
+
+def _get_ancestors_by_depth(df, graph, max_depth=None):
+    max_depth = len(graph) if max_depth is None else max_depth
+
+    visited = {df}
+    ancestors_by_depth = {0: {df}}
+
+    depth = 0
+    while depth < max_depth and \
+            len(ancestors_by_depth[depth]) > 0:  # There are unexplored nodes
+
+        cur_layer = ancestors_by_depth[depth]
+        depth += 1
+        ancestors_by_depth[depth] = set()
+        for cur in cur_layer:
+            for neighbor in graph[cur]:
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    ancestors_by_depth[depth].add(neighbor)
+
+    return ancestors_by_depth

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -1,0 +1,52 @@
+import unittest
+
+import pandasql as ps
+from pandasql.core import COST_MODEL
+
+
+class TestCostModel(unittest.TestCase):
+
+    def test_offloading_rule_out_of_memory(self):
+        return NotImplemented
+
+    def test_offloading_rule_join_then_restrict(self):
+        df_1 = ps.DataFrame([{'n': i, 's': str(i*2)} for i in range(100)])
+        df_2 = ps.DataFrame([{'n': i, 't': str(i*4)} for i in range(100)])
+
+        join = df_1.merge(df_2, on='n')
+        filtered = join[join['s'] + join['t'] < 50]
+        limit = join[:20]
+
+        self.assertFalse(COST_MODEL.should_offload(df_1))
+        self.assertFalse(COST_MODEL.should_offload(df_2))
+        self.assertTrue(COST_MODEL.should_offload(filtered))
+        self.assertTrue(COST_MODEL.should_offload(limit))
+
+    def test_offloading_rule_limit_output(self):
+        df = ps.DataFrame([{'n': i, 's': str(i % 2)} for i in range(100)])
+
+        filtered = df[df['n'] > 25]
+        limit = filtered.head(5)
+
+        self.assertFalse(COST_MODEL.should_offload(filtered))
+        self.assertTrue(COST_MODEL.should_offload(limit))
+
+    def test_offloading_rule_deep_dependency_graph(self):
+        depth = 10
+        size = 10 ** 5
+        step = size // depth
+
+        df = ps.DataFrame([{'n': i, 's': str(i*2)} for i in range(size)])
+        descendants = [df]
+
+        for d in range(step, size, step):
+            parent = descendants[-1]
+            child = parent[parent['n'] > d]
+            descendants.append(child)
+
+        self.assertFalse(COST_MODEL.should_offload(df))
+        self.assertTrue(COST_MODEL.should_offload(descendants[-1]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_frame.py
+++ b/tests/test_data_frame.py
@@ -561,10 +561,8 @@ class TestDataFrame(unittest.TestCase):
         nc = nc[nc['b'] < 9]
         base_nc = base_nc[base_nc['b'] < 9]
 
-
         assertDataFrameEqualsPandas(nc, base_nc)
         assertDataFrameEqualsPandas(nc, expected)
-
 
     def test_column_ordering(self):
         base_df = pd.DataFrame([{'n': i, 's': (i*2)} for i in range(10)])
@@ -582,7 +580,9 @@ class TestDataFrame(unittest.TestCase):
 
         df.compute()
 
-        self.assertEqual(df.memory_usage, base_df.memory_usage(deep=True,index=True).sum())
+        self.assertEqual(df.memory_usage,
+                         base_df.memory_usage(deep=True, index=True).sum())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_offloading.py
+++ b/tests/test_offloading.py
@@ -5,7 +5,7 @@ import pandasql as ps
 from .utils import assertDataFrameEqualsPandas
 
 
-class TestPandasExecution(unittest.TestCase):
+class TestOffloading(unittest.TestCase):
 
     def test_result_synchronization_simple(self):
         base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(10)])


### PR DESCRIPTION
Initial attempt at a simple offloading engine for PandaSQL, with offloading decisions being triggered when one of several "rules" is satisfied by a query. This provides a simple skeleton and some preliminary rules we can use.