### PR TITLE
Adding basic support for drop_duplicates/DISTINCT queries

### DIFF
--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -469,6 +469,18 @@ class DataFrame(BaseFrame):
         """TODO: support other pandas groupby arguments"""
         return GroupByDataFrame(self, by=by, as_index=as_index)
 
+    def drop_duplicates(self, subset=None, keep='first', inplace=False,
+                        ignore_index=False):
+        if subset is not None:
+            raise ValueError('Subset support has not been added')
+        if inplace is True:
+            raise ValueError('In place support has not been added')
+        if ignore_index is True:
+            raise ValueError('Index support has not been added')
+        if keep !='first':
+             raise ValueError('Keep support has not been added')
+        return Projection(self, self.columns.tolist(), drop_duplicates=True)
+
     @require_result
     def __str__(self):
         return str(self.result)
@@ -578,7 +590,7 @@ class UpdateNames(object):
 
 
 class Projection(DataFrame, ArithmeticOperand):
-    def __init__(self, source: DataFrame, col, name=None):
+    def __init__(self, source: DataFrame, col, name=None, drop_duplicates=False):
 
         if isinstance(col, str):
             cols = [col]
@@ -593,12 +605,17 @@ class Projection(DataFrame, ArithmeticOperand):
         if len(pd.Index(cols).difference(source.columns)) > 0:
             raise ValueError("Projection columns {} are not a subset of {}"
                              .format(cols, source.columns))
-        self.columns = source.columns[source.columns.isin(cols)]
 
-        self._sql_query = 'SELECT {} FROM {}'.format(', '.join(self.columns),
+        self.dedup = drop_duplicates
+        self.columns = source.columns[source.columns.isin(cols)]
+        dist = "DISTINCT " if self.dedup is True else ""
+        self._sql_query = 'SELECT {}{} FROM {}'.format(dist,
+                                                     ', '.join(self.columns),
                                                      self.sources[0].name)
 
     def _pandas(self):
+        if self.dedup is True:
+            return self.sources[0].result[self.columns].drop_duplicates()
         return self.sources[0].result[self.columns]
 
     def __hash__(self):

--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -64,7 +64,7 @@ class BaseFrame(object):
                 self._memory_usage = self._cached_result.memory_usage(
                     deep=True, index=True)
             else:
-                # TODO: handle Aggregator, GroupByDataFrame, and GroupByProjection
+                # TODO: handle Aggregator, GroupByDataFrame, GroupByProjection
                 self._memory_usage = None
         return self._memory_usage
 
@@ -500,12 +500,12 @@ class DataFrame(BaseFrame):
                         ignore_index=False):
         if subset is not None:
             raise ValueError('Subset support has not been added')
-        if inplace is True:
+        if inplace:
             raise ValueError('In place support has not been added')
-        if ignore_index is True:
+        if ignore_index:
             raise ValueError('Index support has not been added')
-        if keep !='first':
-             raise ValueError('Keep support has not been added')
+        if keep != 'first':
+            raise ValueError('Keep support has not been added')
         return Projection(self, self.columns.tolist(), drop_duplicates=True)
 
     @require_result
@@ -617,7 +617,8 @@ class UpdateNames(object):
 
 
 class Projection(DataFrame, ArithmeticMixin):
-    def __init__(self, source: DataFrame, col, name=None):
+    def __init__(self, source: DataFrame, col, name=None,
+                 drop_duplicates=False):
 
         if isinstance(col, str):
             cols = [col]
@@ -635,13 +636,13 @@ class Projection(DataFrame, ArithmeticMixin):
 
         self.dedup = drop_duplicates
         self.columns = source.columns[source.columns.isin(cols)]
-        dist = "DISTINCT " if self.dedup is True else ""
+        dist = "DISTINCT " if self.dedup else ""
         self._sql_query = 'SELECT {}{} FROM {}'.format(dist,
-                                                     ', '.join(self.columns),
-                                                     self.sources[0].name)
+                                                       ', '.join(self.columns),
+                                                       self.sources[0].name)
 
     def _pandas(self):
-        if self.dedup is True:
+        if self.dedup:
             return self.sources[0].result[self.columns].drop_duplicates()
         return self.sources[0].result[self.columns]
 

--- a/tests/test_data_frame.py
+++ b/tests/test_data_frame.py
@@ -632,5 +632,34 @@ class TestDataFrame(unittest.TestCase):
         assertDataFrameEqualsPandas(df.p, pd.DataFrame(base_df.p))
         assertDataFrameEqualsPandas(df_1, pd.DataFrame(base_df_1))
 
+    def test_drop_duplicates(self):
+        base_df = pd.DataFrame([{'n': int(i/2), 's': 0} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df_dup = base_df.drop_duplicates()
+        df_dup = df.drop_duplicates()
+
+        sql = df_dup.sql()
+        self.assertEqual(sql, 'SELECT DISTINCT n, s FROM {}'.format(df.name))
+
+        assertDataFrameEqualsPandas(df_dup, base_df_dup)
+
+    def test_drop_duplicates_projection(self):
+        base_df = pd.DataFrame([{'n': int(i/2), 's': 0} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df_n = base_df['n']
+        df_n = df['n']
+
+        base_df_dup = base_df_n.drop_duplicates()
+        df_dup = df_n.drop_duplicates()
+
+        sql = df_dup.sql()
+        self.assertEqual(sql, 'WITH {} AS (SELECT n FROM {}) SELECT DISTINCT n FROM {}'  # noqa
+                              .format(df_n.name, df.name, df_n.name))
+
+        assertDataFrameEqualsPandas(df_dup, pd.DataFrame(base_df_dup))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data_frame.py
+++ b/tests/test_data_frame.py
@@ -603,5 +603,23 @@ class TestDataFrame(unittest.TestCase):
         assertDataFrameEqualsPandas(df.p, pd.DataFrame(base_df.p))
         assertDataFrameEqualsPandas(df_1, pd.DataFrame(base_df_1))
 
+    def test_drop_duplicates(self):
+        base_df = pd.DataFrame([{'n': int(i/2), 's': 0} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df = base_df.drop_duplicates()
+        df = df.drop_duplicates()
+
+        assertDataFrameEqualsPandas(df, base_df)
+
+
+    def test_drop_duplicates_projection(self):
+        base_df = pd.DataFrame([{'n': int(i/2), 's': 0} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df = base_df['n'].drop_duplicates()
+        df = df['n'].drop_duplicates()
+
+        assertDataFrameEqualsPandas(df, pd.DataFrame(base_df))
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pandas_execution.py
+++ b/tests/test_pandas_execution.py
@@ -322,6 +322,24 @@ class TestPandasExecution(unittest.TestCase):
         pd.testing.assert_frame_equal(agg.result, base_agg)
         pd.testing.assert_frame_equal(ordered.result, base_ordered)
 
+    def test_drop_duplicates(self):
+        base_df = pd.DataFrame([{'n': int(i/2), 's': 0} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df_dup = base_df.drop_duplicates()
+        df_dup = df.drop_duplicates()
+
+        assertDataFrameEqualsPandas(df_dup, base_df_dup)
+
+    def test_drop_duplicates_projection(self):
+        base_df = pd.DataFrame([{'n': int(i/2), 's': 0} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df_dup = base_df['n'].drop_duplicates()
+        df_dup = df['n'].drop_duplicates()
+
+        assertDataFrameEqualsPandas(df_dup, pd.DataFrame(base_df_dup))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Supporting `drop_duplicates()`. Limitations - does not allow column subsets due to SQL query structure and does not currently support any advanced options. 

Closes #12 