### PR TITLE
DAG Improvement: Pandas-only Sources

### DIFF
--- a/pandasql/graph_utils.py
+++ b/pandasql/graph_utils.py
@@ -2,16 +2,19 @@ from queue import Queue
 from collections import defaultdict
 
 
-def _get_dependency_graph(table):
+def _get_dependency_graph(df, on='sqlite'):
     dependencies = {}
 
     def add_dependencies(child):
         dependencies[child] = list(child.sources)
+        if on == 'pandas':
+            dependencies[child] += list(child.pandas_sources)
+
         for parent in dependencies[child]:
             if parent not in dependencies:
                 add_dependencies(parent)
 
-    add_dependencies(table)
+    add_dependencies(df)
     return dependencies
 
 


### PR DESCRIPTION
In a handful of cases, we were not tracking some dependencies as "sources". This changes that. 

For example, every `Selection` object maintained a `Criterion` object as an attribute, but this `Criterion` was not a source. This was a fine design choice when we were only concerned with executing on SQLite. But when executing something like `df[df['a'] < 5]` on Pandas, the `Criterion` produced by `df['a'] < 5` needs to be computed itself (as a Pandas series). On a relational DB, no such equivalent computation is done. So, we can now track such objects as Pandas-only sources.