### PR TITLE
Step-by-Step Pandas Execution with Memory Predictions

### DIFF
--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -1101,7 +1101,9 @@ class Aggregator(DataFrame):
         # same as that of a single value of the column. This assumption holds
         # for fixed-size types like ints and floats, but not for strings.
         prev_rows = data_source._count
-        return num_groups / prev_rows * data_source.memory_usage().sum()
+        index_usage = data_source.memory_usage()['Index']
+        row_usage = data_source.memory_usage()[self.columns].sum()
+        return index_usage + (num_groups / prev_rows * row_usage)
 
     def _pandas(self):
         if self.grouped:

--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -153,8 +153,8 @@ class BaseFrame(object):
                     # The next operation is too big for Pandas, so run the
                     # remainder of the computation on SQLite
                     else:
-                        # TODO: Make a decision for whether to transfer
-                        # dependencies or recompute them on SQLite
+                        # TODO: For each dependency, decide whether it should
+                        # be transferred or recomputed on SQLite
                         if not _is_computable(t, on='sqlite'):
                             # All dependencies do not exist on SQLite,
                             # so transfer all sources
@@ -167,8 +167,6 @@ class BaseFrame(object):
 
                         # Break out of loop; no more dependencies to compute
                         break
-
-        return self.result
 
     def _compute_sqlite(self):
 
@@ -195,8 +193,6 @@ class BaseFrame(object):
                 # Compute stats about result
                 if isinstance(self._cached_result, pd.DataFrame):
                     self._count = len(self._cached_result)
-
-        return self.result
 
     def _pandas(self):
         raise NotImplementedError("To be implemented by subclasses")
@@ -784,7 +780,6 @@ class Selection(DataFrame):
             self.sources[0].name, self.pandas_sources[0])
 
     def _predict_memory_from_sources(self):
-        print(self.name, type(self.pandas_sources[0].result))
         new_rows = self.pandas_sources[0].result.sum()
         prev_rows = self.sources[0]._count
         kept_ratio = new_rows / prev_rows

--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -1317,7 +1317,7 @@ class Arithmetic(DataFrame, ArithmeticMixin):
             self._operation_as_str(), self.sources[0].name)
 
     def _predict_memory_from_sources(self):
-        return self.sources[0].memory_usage().sum()
+        return max([o._predict_memory_from_sources() for o in self.operands])
 
     def _pandas(self):
         results = [op.result[op.columns[0]]

--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -279,7 +279,7 @@ class Criterion(BaseFrame):
         projs = [s for s in self.sources if isinstance(s, Projection)]
         assert len(projs) > 0
         nrows = projs[0].sources[0].stats.iloc[:, 0]['count']
-        index_usage = projs[0].sources[0].memory_usage['Index']
+        index_usage = projs[0].sources[0].memory_usage()['Index']
         return index_usage + nrows    # assuming 1 byte/bool?
 
     def _pandas(self):
@@ -711,8 +711,8 @@ class Projection(DataFrame, ArithmeticMixin):
         return self.sources[0].result[self.columns]
 
     def _predict_memory_from_sources(self):
-        index_usage = self.sources[0].memory_usage['Index']
-        return index_usage + self.sources[0].memory_usage[self.columns].sum()
+        index_usage = self.sources[0].memory_usage()['Index']
+        return index_usage + self.sources[0].memory_usage()[self.columns].sum()
 
     def __hash__(self):
         return super().__hash__()
@@ -812,7 +812,7 @@ class Join(DataFrame):
 
     def _predict_memory_from_sources(self):
         def merge_size(l_frame, r_frame, join_key, how='inner'):
-            # TODO: have to ensure that l_frame and r_frame are already computed
+            # TODO: have to ensure that l_frame & r_frame are already computed
             l_groups = l_frame.groupby(join_key).size()
             r_groups = r_frame.groupby(join_key).size()
             l_keys = set(l_groups.index)
@@ -849,10 +849,10 @@ class Join(DataFrame):
         new_row_size = 0
         for c in self.columns:
             if c in self.sources[0].columns:
-                new_row_size += self.sources[0].memory_usage[c] / \
+                new_row_size += self.sources[0].memory_usage()[c] / \
                     self.sources[0].stats[c]['count']
             else:
-                new_row_size += self.sources[1].memory_usage[c] / \
+                new_row_size += self.sources[1].memory_usage()[c] / \
                     self.sources[1].stats[c]['count']
 
         return new_row_size * nrows
@@ -936,7 +936,7 @@ class GroupByDataFrame(BaseFrame):
                                            self.groupby_cols)
 
     def _predict_memory_from_sources(self):
-        return 1000 # TODO: just a guess
+        return 1000     # TODO: just a guess
 
     def _pandas(self):
         grouped = self.sources[0].result.groupby(self.groupby_cols,
@@ -972,7 +972,7 @@ class GroupByProjection(GroupByDataFrame):
                     self.columns.to_list())
 
     def _predict_memory_from_sources(self):
-        return 1000 # TODO: just a guess
+        return 1000     # TODO: just a guess
 
 ##############################################################################
 #                                Aggregators

--- a/pandasql/core.py
+++ b/pandasql/core.py
@@ -690,7 +690,6 @@ class Update(object):
                                                      self.source.name)
 
     def _predict_memory_from_sources(self):
-        print(type(self.source))
         mem_usage = self.source.memory_usage()
         old_mem = mem_usage.sum()
 
@@ -715,7 +714,6 @@ class Update(object):
         else:
             raise TypeError(f'Unexpected value of type {type(self.value)}')
 
-        print('mem', old_mem, new_mem, old_mem + new_mem)
         return old_mem + new_mem
 
     def __str__(self):
@@ -1104,7 +1102,6 @@ class Aggregator(DataFrame):
             self.final_type = None
 
     def _predict_memory_from_sources(self):
-        print('enter', id(self))
         if self.grouped:
             # When grouping by columns (C1, ..., Cn), if the columns are
             # independent, the number of unique groups will be the product
@@ -1121,17 +1118,10 @@ class Aggregator(DataFrame):
             row_usage = data_source.memory_usage()[self.columns].sum()
             new_prediction = index_usage + (num_groups / prev_rows * row_usage)
         else:
-            print('DEBUG')
             data_source = self.sources[0]
-            print(type(data_source), data_source.name, id(data_source))
-            print(data_source.columns.dtype)
-            print(len(data_source.columns))
-            print(sys.getsizeof(data_source.columns))
             index_usage = data_source.columns.memory_usage(deep=True)
-            print(index_usage)
             new_len = len(data_source.columns)
             new_prediction = index_usage + new_len * 8
-            print(new_prediction)
         # TODO: This assumes that the size of the aggregated result will be the
         # same as that of a single value of the column. This assumption holds
         # for fixed-size types like ints and floats, but not for strings.

--- a/pandasql/cost_model.py
+++ b/pandasql/cost_model.py
@@ -33,11 +33,6 @@ class CostModel(object):
 FARTHEST_DEPENDENCE = 1   # TODO: How much should we allow? Maybe 2-3?
 
 
-def _out_of_memory(df, graph):
-    # TODO: How should we estimate memory usage of a query?
-    return NotImplemented
-
-
 def _join_then_restrict(df, graph):
     for node in graph.keys():
         # If result is already cached, no point in looking at it
@@ -83,7 +78,6 @@ def _fallback_operation(df, graph):
 
 OFFLOADING_RULES = [
     _fallback_operation,
-    # _out_of_memory,
     _join_then_restrict,
     _limit_output,
     _deep_dependency_graph,

--- a/tests/test_data_frame.py
+++ b/tests/test_data_frame.py
@@ -609,9 +609,9 @@ class TestDataFrame(unittest.TestCase):
         df = ps.DataFrame(base_df)
 
         df.compute()
-
-        self.assertEqual(df.memory_usage,
-                         base_df.memory_usage(deep=True, index=True).sum())
+        pd.testing.assert_series_equal(df.memory_usage(),
+                                       base_df.memory_usage(deep=True,
+                                                            index=True))
 
     def test_attr_access(self):
         base_df = pd.DataFrame([{'n': i, 's': (i*2)} for i in range(10)])

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -63,7 +63,10 @@ class TestMemoryPredictor(unittest.TestCase):
         self.checkMemoryPrediction(union)
 
     def test_aggregate_memory_prediction(self):
-        return NotImplemented
+        df_1 = ps.DataFrame([{'n': i, 's': str(i)}
+                             for i in range(10, 1000, 10)])
+        summed = df_1.sum()
+        self.checkMemoryPrediction(summed)
 
     def test_grouped_aggregate_memory_prediction(self):
         return NotImplemented

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -19,10 +19,8 @@ class TestMemoryPredictor(unittest.TestCase):
 
         df._compute_pandas()
         actual = df._cached_result.memory_usage(deep=True, index=True)
-        print('actual', actual)
         if isinstance(actual, pd.Series):
             actual = actual.sum()
-        print(type(df), actual, predicted)
 
         self.assertAlmostEqual(actual, predicted, delta=delta * actual)
 
@@ -68,14 +66,17 @@ class TestMemoryPredictor(unittest.TestCase):
         self.checkMemoryPrediction(union)
 
     def test_aggregate_memory_prediction(self):
-        df_1 = ps.DataFrame([{'n': i, 's': str(i)}
-                             for i in range(10, 1000, 10)])
-        summed = df_1.sum()
-        self.checkMemoryPrediction(summed)
+        df = ps.DataFrame([{'n': i, 's': str(i), 'f': i ** 2.0}
+                           for i in range(10, 1000)])
+        summed = df.sum()
+        # TODO: Aggregate prediction is not super accurate because of
+        # weird issues with Pandas memory usage for non-grouped aggregates.
+        # Likely not a big deal since aggregates are usually tiny in size.
+        self.checkMemoryPrediction(summed, delta=0.3)
 
     def test_grouped_aggregate_memory_prediction(self):
         df = ps.DataFrame([{'n': i/4, 's': str(i)}
-                             for i in range(10, 1000, 10)])
+                           for i in range(10, 1000, 10)])
         prod = df.groupby('n').prod()
         self.checkMemoryPrediction(prod)
 
@@ -86,8 +87,8 @@ class TestMemoryPredictor(unittest.TestCase):
 
     def test_arithmetic_projection_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])
-        add = df.n + df.s
-        self.checkMemoryPrediction(add)
+        added = df.n + df.s
+        self.checkMemoryPrediction(added)
 
     def test_write_constant_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': str(i*2)} for i in range(100)])

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -6,6 +6,7 @@ import pandasql as ps
 
 
 class TestMemoryPredictor(unittest.TestCase):
+    # TODO(important): Add tests for all objects' memory predictors!
 
     def setUp(self):
         self.THRESHOLD = 0.2

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pandasql as ps
 
 
-class TestCostModel(unittest.TestCase):
+class TestMemoryPredictor(unittest.TestCase):
 
     def setUp(self):
         self.THRESHOLD = 0.2

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -1,0 +1,43 @@
+import unittest
+
+import pandas as pd
+
+import pandasql as ps
+
+
+class TestCostModel(unittest.TestCase):
+
+    def setUp(self):
+        self.THRESHOLD = 0.2
+
+    def test_simple_dataframe_usage(self):
+        base_df = pd.DataFrame([{'n': i, 's1': str(i*2)} for i in range(10)])
+        df = ps.DataFrame(base_df)
+        pd_mem = base_df.memory_usage(deep=True, index=True).sum()
+        ps_mem = df._predict_memory_from_sources()
+        self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
+
+    def test_projection_dataframe_usage(self):
+        base_df = pd.DataFrame([{'n': i, 's1': str(i*2)} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_df_1 = base_df.n
+        df_1 = df.n
+
+        pd_mem = base_df_1.memory_usage(deep=True, index=True)
+        ps_mem = df_1._predict_memory_from_sources()
+        self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
+
+    def test_criterion_dataframe_usage(self):
+        base_df = pd.DataFrame([{'n': i, 's1': str(i*2)} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_sel = base_df.n > 4
+        sel = df.n > 4
+
+        pd_mem = base_sel.memory_usage(deep=True, index=True)
+        ps_mem = sel._predict_memory_from_sources()
+        self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -69,7 +69,10 @@ class TestMemoryPredictor(unittest.TestCase):
         self.checkMemoryPrediction(summed)
 
     def test_grouped_aggregate_memory_prediction(self):
-        return NotImplemented
+        df_1 = ps.DataFrame([{'n': i/4, 's': str(i)}
+                             for i in range(10, 1000, 10)])
+        summed = df_1.groupby('n').prod()
+        self.checkMemoryPrediction(summed)
 
     def test_arithmetic_constant_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -1,44 +1,85 @@
 import unittest
-
 import pandas as pd
-
 import pandasql as ps
+from .utils import compute_all_ancestors
 
 
 class TestMemoryPredictor(unittest.TestCase):
     # TODO(important): Add tests for all objects' memory predictors!
 
-    def setUp(self):
-        self.THRESHOLD = 0.2
+    def checkMemoryPrediction(self, df: ps.DataFrame, base_df: pd.DataFrame,
+                              delta=0.1):
+        pd_mem = base_df.memory_usage(deep=True, index=True)
+        if isinstance(pd_mem, pd.Series):
+            pd_mem = pd_mem.sum()
 
-    def test_simple_dataframe_usage(self):
-        base_df = pd.DataFrame([{'n': i, 's1': str(i*2)} for i in range(10)])
-        df = ps.DataFrame(base_df)
-        pd_mem = base_df.memory_usage(deep=True, index=True).sum()
+        compute_all_ancestors(df)
         ps_mem = df._predict_memory_from_sources()
-        self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
 
-    def test_projection_dataframe_usage(self):
-        base_df = pd.DataFrame([{'n': i, 's1': str(i*2)} for i in range(10)])
+        self.assertAlmostEqual(pd_mem, ps_mem, delta=delta * pd_mem)
+
+    def test_simple_memory_prediction(self):
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(10)])
+        df = ps.DataFrame(base_df)
+        self.checkMemoryPrediction(df, base_df, delta=0.0)
+
+    def test_projection_memory_prediction(self):
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(10)])
         df = ps.DataFrame(base_df)
 
-        base_df_1 = base_df.n
-        df_1 = df.n
+        base_proj = base_df.n
+        proj = df.n
+        self.checkMemoryPrediction(proj, base_proj, delta=0.0)
 
-        pd_mem = base_df_1.memory_usage(deep=True, index=True)
-        ps_mem = df_1._predict_memory_from_sources()
-        self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
-
-    def test_criterion_dataframe_usage(self):
-        base_df = pd.DataFrame([{'n': i, 's1': str(i*2)} for i in range(10)])
+    def test_criterion_memory_prediction(self):
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(10)])
         df = ps.DataFrame(base_df)
 
-        base_sel = base_df.n > 4
-        sel = df.n > 4
+        base_criterion = base_df.n > 4
+        criterion = df.n > 4
+        self.checkMemoryPrediction(criterion, base_criterion, delta=0.0)
 
-        pd_mem = base_sel.memory_usage(deep=True, index=True)
-        ps_mem = sel._predict_memory_from_sources()
-        self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
+    def test_selection_memory_prediction(self):
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_sel = base_df[base_df.n > 4]
+        sel = df[df.n > 4]
+        self.checkMemoryPrediction(sel, base_sel)
+
+    def test_limit_memory_prediction(self):
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(100)])
+        df = ps.DataFrame(base_df)
+
+        base_limit = base_df[:25]
+        limit = df[:25]
+        self.checkMemoryPrediction(limit, base_limit)
+
+    def test_order_by_memory_prediction(self):
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(10)])
+        df = ps.DataFrame(base_df)
+
+        base_ordered = base_df.sort_values(by='n', ascending=False)
+        ordered = df.sort_values(by='n', ascending=False)
+        self.checkMemoryPrediction(ordered, base_ordered)
+
+    def test_join_memory_prediction(self):
+        return NotImplemented
+
+    def test_union_memory_prediction(self):
+        return NotImplemented
+
+    def test_aggregate_memory_prediction(self):
+        return NotImplemented
+
+    def test_grouped_aggregate_memory_prediction(self):
+        return NotImplemented
+
+    def test_arithmetic_memory_prediction(self):
+        return NotImplemented
+
+    def test_write_memory_prediction(self):
+        return NotImplemented
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -69,10 +69,10 @@ class TestMemoryPredictor(unittest.TestCase):
         self.checkMemoryPrediction(summed)
 
     def test_grouped_aggregate_memory_prediction(self):
-        df_1 = ps.DataFrame([{'n': i/4, 's': str(i)}
+        df = ps.DataFrame([{'n': i/4, 's': str(i)}
                              for i in range(10, 1000, 10)])
-        summed = df_1.groupby('n').prod()
-        self.checkMemoryPrediction(summed)
+        prod = df.groupby('n').prod()
+        self.checkMemoryPrediction(prod)
 
     def test_arithmetic_constant_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -83,21 +83,21 @@ class TestMemoryPredictor(unittest.TestCase):
     def test_arithmetic_constant_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])
         added = df.n + 1
-        self.checkMemoryPrediction(added)
+        self.checkMemoryPrediction(added, delta=0.0)
 
     def test_arithmetic_projection_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])
         added = df.n + df.s
-        self.checkMemoryPrediction(added)
+        self.checkMemoryPrediction(added, delta=0.0)
 
     def test_write_constant_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': str(i*2)} for i in range(100)])
         df['int'] = 10
-        self.checkMemoryPrediction(df)
+        self.checkMemoryPrediction(df, delta=0.0)
         df['float'] = 3.14
-        self.checkMemoryPrediction(df)
+        self.checkMemoryPrediction(df, delta=0.0)
         df['str'] = 'pi'
-        self.checkMemoryPrediction(df)
+        self.checkMemoryPrediction(df, delta=0.0)
 
     def test_write_column_memory_prediction(self):
         df = ps.DataFrame([{'n': i, 's': str(i*2)} for i in range(100)])

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pandasql as ps
 
 
-class TestCostModel(unittest.TestCase):
+class TestMemoryPredictor(unittest.TestCase):
 
     def setUp(self):
         self.THRESHOLD = 0.2
@@ -38,6 +38,7 @@ class TestCostModel(unittest.TestCase):
         pd_mem = base_sel.memory_usage(deep=True, index=True)
         ps_mem = sel._predict_memory_from_sources()
         self.assertAlmostEqual(pd_mem, ps_mem, delta=self.THRESHOLD * pd_mem)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_predictor.py
+++ b/tests/test_memory_predictor.py
@@ -68,8 +68,15 @@ class TestMemoryPredictor(unittest.TestCase):
     def test_grouped_aggregate_memory_prediction(self):
         return NotImplemented
 
-    def test_arithmetic_memory_prediction(self):
-        return NotImplemented
+    def test_arithmetic_constant_memory_prediction(self):
+        df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])
+        added = df.n + 1
+        self.checkMemoryPrediction(added)
+
+    def test_arithmetic_projection_memory_prediction(self):
+        df = ps.DataFrame([{'n': i, 's': i*2} for i in range(100)])
+        df.n += df.s
+        self.checkMemoryPrediction(df)
 
     def test_write_memory_prediction(self):
         return NotImplemented

--- a/tests/test_offloading.py
+++ b/tests/test_offloading.py
@@ -89,6 +89,37 @@ class TestOffloading(unittest.TestCase):
 
         ps.memory_utils.SAFETY_FACTOR = old_factor
 
+    def test_pandas_step_out_of_memory(self):
+        ps.offloading_strategy('NEVER')
+
+        size = 10 ** 4
+
+        base_df = pd.DataFrame([{'n': i, 's': str(i*2)} for i in range(size)])
+        base_ordered = base_df.sort_values(by='n', ascending=False)
+        base_limit = base_ordered[:10]
+
+        df = ps.DataFrame(base_df)
+
+        memory_thresh = 10 ** 4
+        new_factor = memory_thresh / psutil.virtual_memory().available
+        old_factor = ps.memory_utils.SAFETY_FACTOR
+        ps.memory_utils.SAFETY_FACTOR = new_factor
+
+        # Should execute, but on SQLite since ordered is expected to run
+        # out of memory. The limit should be small enough to be fetched
+        # back to Pandas from SQLite.
+        ordered = df.sort_values(by='n', ascending=False)
+        limit = ordered[:10]
+        limit.compute()
+        self.assertFalse(ordered._computed_on_pandas)
+        self.assertFalse(ordered._cached_on_sqlite)
+        self.assertFalse(limit._computed_on_pandas)
+        self.assertTrue(limit._cached_on_sqlite)
+        self.assertFalse(limit._out_of_memory)
+        assertDataFrameEqualsPandas(limit, base_limit)
+
+        ps.memory_utils.SAFETY_FACTOR = old_factor
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,3 +23,8 @@ def assertDataFrameEqualsPandas(df: ps.DataFrame,
                                        *args, **kwargs)
     else:
         raise TypeError("Unexpected type {}".format(type(expected_df)))
+
+
+def compute_all_ancestors(df: ps.DataFrame):
+    for source in df.sources + df.pandas_sources:
+        source._compute_pandas()


### PR DESCRIPTION
- Every `DataFrame` now has a `_predict_memory_from_sources` method that uses its (already computed) sources to predict its memory usage.
- Restructured `_compute_pandas` to do "step-by-step" execution of compute DAGs. At each step, we check if the next computation is expected to fit in memory, and if not, we offload the remainder of the computation to SQLite.
- This eliminates the need to compute statistics every time a `DataFrame` result is computed. The handful of times we do need a few stats, they're computed on the fly.
- This also means that we will not be checking for OOM in the `CostModel`, but just in every step of Pandas computation.

Closes #23 